### PR TITLE
bugfix/accurics_remediation_40746610201400757 - Auto Generated Pull Request From Accurics

### DIFF
--- a/demo-terraform/aws/serverless-app/dynamodb.tf
+++ b/demo-terraform/aws/serverless-app/dynamodb.tf
@@ -2,29 +2,33 @@
 
 ## Dynamodb Table
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
-    name = "${var.dynamodb_table_name}-${random_string.uniq.result}"
-  
-    # Under free tier
-    billing_mode   = "PAY_PER_REQUEST"
-  
-    hash_key       = var.dynamodb_table_pkey
+  name = "${var.dynamodb_table_name}-${random_string.uniq.result}"
 
-    attribute {
-        name = var.dynamodb_table_pkey
-        type = "S"
-    }
+  # Under free tier
+  billing_mode = "PAY_PER_REQUEST"
 
-    tags = local.project_tags
+  hash_key = var.dynamodb_table_pkey
+
+  attribute {
+    name = var.dynamodb_table_pkey
+    type = "S"
+  }
+
+  tags = local.project_tags
+
+  server_side_encryption {
+    enabled = true
+  }
 }
 
 ### DynDB data handling IAM policy
 data "aws_iam_policy_document" "dyndb_data_handling_read" {
   statement {
-    sid = "1"
+    sid    = "1"
     effect = "Allow"
     actions = [
-        "dynamodb:GetItem",
-        "dynamodb:Scan",
+      "dynamodb:GetItem",
+      "dynamodb:Scan",
     ]
 
     resources = [
@@ -33,21 +37,21 @@ data "aws_iam_policy_document" "dyndb_data_handling_read" {
   }
 }
 resource "aws_iam_policy" "dyndb_data_handling_read" {
-    name        = "dynbd-${var.dynamodb_table_name}-${random_string.uniq.result}-read"
-    path        = local.iam_path
+  name = "dynbd-${var.dynamodb_table_name}-${random_string.uniq.result}-read"
+  path = local.iam_path
 
-    policy = data.aws_iam_policy_document.dyndb_data_handling_read.json
+  policy = data.aws_iam_policy_document.dyndb_data_handling_read.json
 
-    tags = local.project_tags
+  tags = local.project_tags
 }
 
 ### DynDB data handling IAM policy
 data "aws_iam_policy_document" "dyndb_data_handling_write" {
   statement {
-    sid = "1"
+    sid    = "1"
     effect = "Allow"
     actions = [
-        "dynamodb:PutItem",
+      "dynamodb:PutItem",
     ]
 
     resources = [
@@ -56,21 +60,21 @@ data "aws_iam_policy_document" "dyndb_data_handling_write" {
   }
 }
 resource "aws_iam_policy" "dyndb_data_handling_write" {
-    name        = "dynbd-${var.dynamodb_table_name}-${random_string.uniq.result}-write"
-    path        = local.iam_path
+  name = "dynbd-${var.dynamodb_table_name}-${random_string.uniq.result}-write"
+  path = local.iam_path
 
-    policy = data.aws_iam_policy_document.dyndb_data_handling_write.json
+  policy = data.aws_iam_policy_document.dyndb_data_handling_write.json
 
-    tags = local.project_tags
+  tags = local.project_tags
 }
 
 ### DynDB data handling IAM policy - delete
 data "aws_iam_policy_document" "dyndb_data_handling_delete" {
   statement {
-    sid = "1"
+    sid    = "1"
     effect = "Allow"
     actions = [
-        "dynamodb:DeleteItem",
+      "dynamodb:DeleteItem",
     ]
 
     resources = [
@@ -79,24 +83,24 @@ data "aws_iam_policy_document" "dyndb_data_handling_delete" {
   }
 }
 resource "aws_iam_policy" "dyndb_data_handling_delete" {
-    name        = "dynbd-${var.dynamodb_table_name}-${random_string.uniq.result}-delete"
-    path        = local.iam_path
+  name = "dynbd-${var.dynamodb_table_name}-${random_string.uniq.result}-delete"
+  path = local.iam_path
 
-    policy = data.aws_iam_policy_document.dyndb_data_handling_delete.json
+  policy = data.aws_iam_policy_document.dyndb_data_handling_delete.json
 
-    tags = local.project_tags
+  tags = local.project_tags
 }
 
 ## Attach IAM policy to lambda role
 resource "aws_iam_role_policy_attachment" "dyndb_data_handling_read" {
-    role = aws_iam_role.lambdas["RequestUnicorn"].name
-    policy_arn = aws_iam_policy.dyndb_data_handling_read.arn
+  role       = aws_iam_role.lambdas["RequestUnicorn"].name
+  policy_arn = aws_iam_policy.dyndb_data_handling_read.arn
 }
 resource "aws_iam_role_policy_attachment" "dyndb_data_handling_delete" {
-    role = aws_iam_role.lambdas["RequestUnicorn"].name
-    policy_arn = aws_iam_policy.dyndb_data_handling_delete.arn
+  role       = aws_iam_role.lambdas["RequestUnicorn"].name
+  policy_arn = aws_iam_policy.dyndb_data_handling_delete.arn
 }
 resource "aws_iam_role_policy_attachment" "dyndb_data_handling_write" {
-    role = aws_iam_role.lambdas["RequestUnicorn"].name
-    policy_arn = aws_iam_policy.dyndb_data_handling_write.arn
+  role       = aws_iam_role.lambdas["RequestUnicorn"].name
+  policy_arn = aws_iam_policy.dyndb_data_handling_write.arn
 }


### PR DESCRIPTION
Server Side Encryption can be enabled for AWS DynamoDB tables. 
 In AWS Console - 
 1. Sign in to AWS Console and go to the AWS DynamoDB table.
 2. Select Tables in the navigation pane.
 3. Select the necessary table.
 4. Find Encryption Type under Table details in the Overview tab.
 5. Ensure Encryption is enabled.
 6. Click Save. 
 In Terraform - 
 Set 'server_side_encryption.enabled' to 'true'.